### PR TITLE
Ability to add session with other SocketAcceptPort dynamically

### DIFF
--- a/QuickFIXn/ThreadedSocketAcceptor.cs
+++ b/QuickFIXn/ThreadedSocketAcceptor.cs
@@ -114,6 +114,13 @@ namespace QuickFix
                 {
                     AcceptorSocketDescriptor descriptor = GetAcceptorSocketDescriptor(dict);
                     Session session = sessionFactory_.Create(sessionID, dict);
+
+                    // start descriptor if it was just created and if acceptor is already started
+                    if (isStarted_ && !_disposed && !descriptor.SocketReactor.IsStarted)
+                    {
+                        descriptor.SocketReactor.Start();
+                    }
+
                     descriptor.AcceptSession(session);
                     sessions_[sessionID] = session;
                     return true;

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -23,6 +23,11 @@ namespace QuickFix
             get { lock (sync_) { return state_; } }
         }
 
+        public bool IsStarted
+        {
+            get { return serverThread_ != null; }
+        }
+
         #endregion
 
         #region Private Members
@@ -57,11 +62,8 @@ namespace QuickFix
             acceptorDescriptor_ = acceptorDescriptor;
         }
 
-        public bool IsStarted { get; private set; }
-
         public void Start()
         {
-            IsStarted = true;
             serverThread_ = new Thread(new ThreadStart(Run));
             serverThread_.Start();
         }

--- a/QuickFIXn/ThreadedSocketReactor.cs
+++ b/QuickFIXn/ThreadedSocketReactor.cs
@@ -57,8 +57,11 @@ namespace QuickFix
             acceptorDescriptor_ = acceptorDescriptor;
         }
 
+        public bool IsStarted { get; private set; }
+
         public void Start()
         {
+            IsStarted = true;
             serverThread_ = new Thread(new ThreadStart(Run));
             serverThread_.Start();
         }

--- a/UnitTests/SessionDynamicTest.cs
+++ b/UnitTests/SessionDynamicTest.cs
@@ -356,6 +356,25 @@ namespace UnitTests
         }
 
         [Test]
+        public void AddSessionDynamicWithDifferentPortTest()
+        {
+            StartEngine(false);
+
+            // Add the dynamic acceptor with another port and ensure that we can now log on
+            string dynamicCompID = "acc10";
+            var sessionID = CreateSessionID(dynamicCompID);
+            var sessionConfig = CreateSessionConfig(dynamicCompID, false);
+            sessionConfig.SetString(SessionSettings.SOCKET_ACCEPT_PORT, AcceptPort2.ToString());
+
+            _acceptor.AddSession(sessionID, sessionConfig);
+
+            var socket = ConnectToEngine(AcceptPort2);
+            SendLogon(socket, dynamicCompID);
+
+            Assert.IsTrue(WaitForLogonStatus(dynamicCompID), "Failde to logon dynamic added acceptor session with another port");
+        }
+
+        [Test]
         public void DifferentPortForAcceptorTest()
         {
             //create two sessions with two different SOCKET_ACCEPT_PORT


### PR DESCRIPTION
Now when we adding session configured with other **SocketAcceptPort** to the **ThreadedSocketAcceptor** that is already started then we actually can not logon and even connect from specified port.
This pull request will fix it.